### PR TITLE
Update to Geoserver 2.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a build of Geoserver that is based on [the official Geoserver Docker rep
 
 - Running as a non-root user
 - Builds for multiple architectures: linux/amd64 and linux/arm64/v8
-- Includes the [Cloud Optimized GeoTIFF (COG)](https://docs.geoserver.org/main/en/user/community/cog/index.html) + [OpenID Connect plugin](https://docs.geoserver.org/main/en/user/community/oauth2/index.html) + [WPS plugin](https://docs.geoserver.org/main/en/user/services/wps/install.html)
+- Includes the [Cloud Optimized GeoTIFF (COG)](https://docs.geoserver.org/main/en/user/community/cog/index.html) + [OpenID Connect plugin](https://docs.geoserver.org/main/en/user/community/oauth2/index.html)
 
 ## Enable OpenID Connect
 


### PR DESCRIPTION
This PR updates Geoserver to 2.26.2

- Remove unused WPS plugin
- Update Tomcat to 9.0.104
- Do not expose Tomcat version via web by setting showServerInfo="false" (e.g. by browsing to /geoserver/web/test)